### PR TITLE
Change dependabot package-ecosystem schedule interval

### DIFF
--- a/src/main/java/org/openrewrite/github/ChangeDependabotScheduleInterval.java
+++ b/src/main/java/org/openrewrite/github/ChangeDependabotScheduleInterval.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.github;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.yaml.JsonPathMatcher;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.YamlVisitor;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ChangeDependabotScheduleInterval extends Recipe {
+    @Option(displayName = "Package ecosystem",
+            description = "The `package-ecosystem` to make updates on.",
+            example = "maven")
+    String packageEcosystem;
+
+    @Option(displayName = "Schedule interval",
+            description = "The schedule `interval` value the `package-ecosystem` should use.",
+            valid = {"daily", "weekly", "monthly"},
+            example = "weekly")
+    String interval;
+
+    @Override
+    public String getDisplayName() {
+        return "Change `dependabot` schedule interval";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Change the schedule interval for a given package-ecosystem in a `dependabot.yml` configuration file. " +
+                "[The available configuration options for `dependabot` are listed on GitHub](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates).";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        Set<String> tags = new HashSet<>();
+        tags.add("dependabot");
+        tags.add("dependencies");
+        tags.add("github");
+        return tags;
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new HasSourcePath<>(".github/dependabot.yml");
+    }
+
+    @Override
+    protected YamlVisitor<ExecutionContext> getVisitor() {
+        return new YamlIsoVisitor<ExecutionContext>() {
+            private final JsonPathMatcher targetEcosystem = new JsonPathMatcher("$.updates[?(@.package-ecosystem =~ '" + packageEcosystem + "')].schedule.interval");
+
+            @Override
+            public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                if (targetEcosystem.encloses(getCursor()) && !((Yaml.Scalar) entry.getValue()).getValue().equals(interval)) {
+                    return super.visitMappingEntry(entry.withValue(((Yaml.Scalar) entry.getValue()).withValue(interval)), ctx);
+                }
+                return super.visitMappingEntry(entry, ctx);
+            }
+        };
+    }
+
+}

--- a/src/main/resources/META-INF/rewrite/github.yml
+++ b/src/main/resources/META-INF/rewrite/github.yml
@@ -27,3 +27,31 @@ recipeList:
         workflow_dispatch:
       acceptTheirs: true
       fileMatcher: '.github/workflows/*.yml'
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.github.DependabotCheckForGithubActionsUpdatesDaily
+displayName: Check for `github-actions` updates daily
+description: Set `dependabot` to check for `github-actions` updates daily.
+tags:
+  - demo
+  - dependabot
+  - dependencies
+  - github
+recipeList:
+  - org.openrewrite.github.ChangeDependabotScheduleInterval:
+      packageEcosystem: github-actions
+      interval: daily
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.github.DependabotCheckForGithubActionsUpdatesWeekly
+displayName: Check for `github-actions` updates weekly
+description: Set `dependabot` to check for `github-actions` updates weekly.
+tags:
+  - demo
+  - dependabot
+  - dependencies
+  - github
+recipeList:
+  - org.openrewrite.github.ChangeDependabotScheduleInterval:
+      packageEcosystem: github-actions
+      interval: weekly

--- a/src/test/kotlin/org/openrewrite/github/ChangeDependabotScheduleIntervalTest.kt
+++ b/src/test/kotlin/org/openrewrite/github/ChangeDependabotScheduleIntervalTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.github
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.openrewrite.yaml.YamlRecipeTest
+import java.nio.file.Path
+
+class ChangeDependabotScheduleIntervalTest : YamlRecipeTest {
+    @Test
+    fun `change dependabot schedule interval`(@TempDir tempDir: Path) = assertChanged(
+        recipe = ChangeDependabotScheduleInterval("github-actions", "weekly"),
+        before = tempDir.resolve(".github/dependabot.yml").toFile().apply {
+            parentFile.mkdirs()
+            writeText(//language=yml
+                """
+                    version: 2
+                    updates:
+                      - package-ecosystem: github-actions
+                        directory: /
+                        schedule:
+                          interval: daily
+                      - package-ecosystem: maven
+                        directory: /
+                        schedule:
+                          interval: weekly
+                      - package-ecosystem: gradle
+                        directory: /
+                        schedule:
+                          interval: monthly
+                """.trimIndent()
+            )
+        },
+        relativeTo = tempDir,
+        after = """
+            version: 2
+            updates:
+              - package-ecosystem: github-actions
+                directory: /
+                schedule:
+                  interval: weekly
+              - package-ecosystem: maven
+                directory: /
+                schedule:
+                  interval: weekly
+              - package-ecosystem: gradle
+                directory: /
+                schedule:
+                  interval: monthly
+        """
+    )
+
+    @Test
+    fun `do not change when no matching package-ecosystem`(@TempDir tempDir: Path) = assertUnchanged(
+        recipe = ChangeDependabotScheduleInterval("npm", "weekly"),
+        before = tempDir.resolve(".github/dependabot.yml").toFile().apply {
+            parentFile.mkdirs()
+            writeText(//language=yml
+                """
+                    version: 2
+                    updates:
+                      - package-ecosystem: github-actions
+                        directory: /
+                        schedule:
+                          interval: daily
+                          time: "09:00"
+                      - package-ecosystem: maven
+                        directory: /
+                        schedule:
+                          interval: weekly
+                          time: "09:00"
+                          timezone: "Asia/Tokyo"
+                      - package-ecosystem: gradle
+                        directory: /
+                        schedule:
+                          interval: monthly
+                          day: sunday
+                """
+            )
+        },
+        relativeTo = tempDir
+    )
+
+    @Test
+    fun `do not change when configuration already matches`(@TempDir tempDir: Path) = assertUnchanged(
+        recipe = ChangeDependabotScheduleInterval("github-actions", "daily"),
+        before = tempDir.resolve(".github/dependabot.yml").toFile().apply {
+            parentFile.mkdirs()
+            writeText(//language=yml
+                """
+                    version: 2
+                    updates:
+                      - package-ecosystem: github-actions
+                        directory: /
+                        schedule:
+                          interval: daily
+                      - package-ecosystem: maven
+                        directory: /
+                        schedule:
+                          interval: weekly
+                      - package-ecosystem: gradle
+                        directory: /
+                        schedule:
+                          interval: monthly
+                """
+            )
+        },
+        relativeTo = tempDir
+    )
+
+}


### PR DESCRIPTION
Changes the `schedule.interval` of a selected dependabot package-ecosystem-- I've included two declarative recipes to enable faster demoing, one which sets the interval of `github-actions` to `daily`, and another which sets the interval of `github-actions` to weekly.