### PR TITLE
Fix AutoCancelInProgressWorkflow to use default settings which is to use the provided github token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: styfle/cancel-workflow-action@0.9.1
         with:
-          access_token: ${{secrets.WORKFLOWS_ACCESS_TOKEN}}
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
- Use latest of 0.9.1
- Mention styfle/cancel-workflow-action specifically
- Have the default setting be to use `github.token` rather than requiring a user-provided token (though one can be provided)