### PR TITLE
Fixed NPE when creating the recipe with RecipeIntrospectionUtils

### DIFF
--- a/src/main/java/org/openrewrite/github/AddCronTrigger.java
+++ b/src/main/java/org/openrewrite/github/AddCronTrigger.java
@@ -51,7 +51,7 @@ public class AddCronTrigger extends Recipe {
     @VisibleForTesting
     AddCronTrigger(String cron, @Nullable String workflowFileMatcher, Random random) {
         this.random = random;
-        this.cron = parseExpression(cron);
+        this.cron = cron;
 
         if (StringUtils.isBlank(workflowFileMatcher)) {
             this.workflowFileMatcher = ".github/workflows/*.yml";
@@ -100,11 +100,12 @@ public class AddCronTrigger extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+        String parsedCron = parseExpression(cron);
         return Preconditions.check(new HasSourcePath<>(workflowFileMatcher), new MergeYaml(
                 "$.on",
                 String.format(
                         "schedule:%n" +
-                        "  - cron: \"%s\"", cron),
+                        "  - cron: \"%s\"", parsedCron),
                 true,
                 null).getVisitor());
     }

--- a/src/test/java/org/openrewrite/github/AddCronTriggerTest.java
+++ b/src/test/java/org/openrewrite/github/AddCronTriggerTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.RecipeIntrospectionUtils;
 import org.openrewrite.test.RewriteTest;
 
 import java.util.Random;
@@ -175,5 +177,10 @@ class AddCronTriggerTest implements RewriteTest {
             spec -> spec.path(".github/workflows/ci.yml")
           )
         );
+    }
+
+    @Test
+    void constructRecipeWithRecipeIntrospectionUtilsShouldNotFail() {
+        RecipeIntrospectionUtils.constructRecipe(AddCronTrigger.class);
     }
 }


### PR DESCRIPTION
## What's changed?
Moved the logic from the constructor where we were parsing the cron parameter to the getVisitor

## What's your motivation?
With recent changes in https://github.com/openrewrite/rewrite/pull/3404, it's no longer valid to do some logic with parameters in the constructor, since they can be not set up yet (nulls) and injected later on by reflection.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Any additional context
Detected this error while running the `org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_0` recipe

### Checklist
- [x] I've added unit tests to cover both positive and negative cases