### PR TITLE
Rename GitHub Actions for Gradle

### DIFF
--- a/src/main/java/org/openrewrite/github/ChangeAction.java
+++ b/src/main/java/org/openrewrite/github/ChangeAction.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.github;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.yaml.ChangeValue;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChangeAction extends Recipe {
+    @Option(displayName = "Action",
+            description = "Name of the action to match.",
+            example = "gradle/wrapper-validation-action")
+    String oldAction;
+
+    @Option(displayName = "Action",
+            description = "Name of the action to use instead.",
+            example = "gradle/actions/wrapper-validation")
+    String newAction;
+
+    @Option(displayName = "Version",
+            description = "New version to use.",
+            example = "v3")
+    String newVersion;
+
+    @Override
+    public String getDisplayName() {
+        return "Change GitHub Action";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Change a GitHub Action in any `.github/workflows/*.yml` file.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new FindSourceFiles(".github/workflows/*.yml"),
+                new ChangeValue(
+                        "$.jobs..steps[?(@.uses =~ '" + oldAction + "(?:@.+)?')].uses",
+                        newAction + '@' + newVersion).getVisitor());
+    }
+}

--- a/src/main/resources/META-INF/rewrite/gradle.yml
+++ b/src/main/resources/META-INF/rewrite/gradle.yml
@@ -1,0 +1,41 @@
+#
+# Copyright 2024 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.github.gradle.RenameWrapperValidationAction
+displayName: Rename `gradle/wrapper-validation-action` to `gradle/actions/wrapper-validation`
+description: Rename the deprecated `gradle/wrapper-validation-action` to `gradle/actions/wrapper-validation@v3`.
+tags:
+  - github
+  - gradle
+recipeList:
+  - org.openrewrite.github.ChangeAction:
+      oldAction: gradle/wrapper-validation-action
+      newAction: gradle/actions/wrapper-validation
+      newVersion: v3
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.github.gradle.RenameGradleBuildActionToSetupGradle
+displayName: Rename `gradle/gradle-build-action` to `gradle/actions/setup-gradle`
+description: Rename the deprecated `gradle/gradle-build-action` to `gradle/actions/setup-gradle@v3`.
+tags:
+  - github
+  - gradle
+recipeList:
+  - org.openrewrite.github.ChangeAction:
+      oldAction: gradle/gradle-build-action
+      newAction: gradle/actions/setup-gradle
+      newVersion: v3

--- a/src/test/java/org/openrewrite/github/ChangeActionTest.java
+++ b/src/test/java/org/openrewrite/github/ChangeActionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.github;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.yaml.Assertions.yaml;
+
+class ChangeActionTest implements RewriteTest {
+    @DocumentExample
+    @Test
+    void updateActionVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeAction(
+            "gradle/wrapper-validation-action",
+            "gradle/actions/wrapper-validation",
+            "v3")),
+          //language=yaml
+          yaml(
+            """
+              jobs:
+                deploy:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - name: Checkout
+                      uses: actions/checkout@v4
+                    - name: Validate wrapper
+                      uses: gradle/wrapper-validation-action@v2
+              """,
+            """
+              jobs:
+                deploy:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - name: Checkout
+                      uses: actions/checkout@v4
+                    - name: Validate wrapper
+                      uses: gradle/actions/wrapper-validation@v3
+              """,
+            source -> source.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void setupGradleYamlRecipe() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.github.gradle.RenameGradleBuildActionToSetupGradle"),
+          //language=yaml
+          yaml(
+            """
+              jobs:
+                deploy:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - name: Checkout
+                      uses: actions/checkout@v4
+                    - uses: gradle/gradle-build-action@v3
+              """,
+            """
+              jobs:
+                deploy:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - name: Checkout
+                      uses: actions/checkout@v4
+                    - uses: gradle/actions/setup-gradle@v3
+              """,
+            source -> source.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Add a new configurable imperative recipe, along with two declarative recipes for Gradle Actions renamed recently

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite-github-actions/issues/101
- #101