### PR TITLE
Find GitHub Actions missing a timeout

### DIFF
--- a/src/main/java/org/openrewrite/github/FindMissingTimeout.java
+++ b/src/main/java/org/openrewrite/github/FindMissingTimeout.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.github;
+
+import org.openrewrite.*;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.yaml.JsonPathMatcher;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.search.FindKey;
+import org.openrewrite.yaml.tree.Yaml;
+
+public class FindMissingTimeout extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Find jobs missing timeout";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Find GitHub Actions jobs missing a timeout.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new FindSourceFiles(".github/workflows/*.yml"), new YamlIsoVisitor<ExecutionContext>() {
+            @Override
+            public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                Yaml.Mapping.Entry job = super.visitMappingEntry(entry, ctx);
+                if (new JsonPathMatcher("$.jobs.*.*").matches(getCursor()) &&
+                    FindKey.find(job, "$..timeout-minutes").isEmpty()) {
+                    return SearchResult.found(job, "missing: $.jobs.*.timeout-minutes");
+                }
+                return job;
+            }
+        });
+    }
+}

--- a/src/test/java/org/openrewrite/github/FindMissingTimeoutTest.java
+++ b/src/test/java/org/openrewrite/github/FindMissingTimeoutTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.github;
 
 import org.junit.jupiter.api.Test;
+
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/src/test/java/org/openrewrite/github/FindMissingTimeoutTest.java
+++ b/src/test/java/org/openrewrite/github/FindMissingTimeoutTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.github;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.yaml.Assertions.yaml;
+
+class FindMissingTimeoutTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new FindMissingTimeout());
+    }
+
+    @DocumentExample
+    @Test
+    void findMissingTimeout() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: actions/checkout@v2
+                    - name: Run a one-line script
+                      run: echo Hello, world!
+              """,
+            """
+              jobs:
+                ~~(missing: $.jobs.*.timeout-minutes)~~>build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: actions/checkout@v2
+                    - name: Run a one-line script
+                      run: echo Hello, world!
+              """,
+            spec -> spec.path(".github/workflows/build.yml")
+          )
+        );
+    }
+
+    @Test
+    void siblingJobHasTimeout() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: actions/checkout@v2
+                    - name: Run a one-line script
+                      run: echo Hello, world!
+                package:
+                  runs-on: ubuntu-latest
+                  timeout-minutes: 10
+                  steps:
+                    - uses: actions/checkout@v2
+                    - name: Run a one-line script
+                      run: echo Hello, world!
+              """,
+            """
+              jobs:
+                ~~(missing: $.jobs.*.timeout-minutes)~~>build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: actions/checkout@v2
+                    - name: Run a one-line script
+                      run: echo Hello, world!
+                package:
+                  runs-on: ubuntu-latest
+                  timeout-minutes: 10
+                  steps:
+                    - uses: actions/checkout@v2
+                    - name: Run a one-line script
+                      run: echo Hello, world!
+              """,
+            spec -> spec.path(".github/workflows/build.yml")
+          )
+        );
+    }
+
+    @Test
+    void jobHasTimeout() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  timeout-minutes: 10
+                  steps:
+                    - uses: actions/checkout@v2
+                    - name: Run a one-line script
+                      run: echo Hello, world!
+              """,
+            spec -> spec.path(".github/workflows/build.yml")
+          )
+        );
+    }
+
+    @Test
+    void stepHasTimeout() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: actions/checkout@v2
+                      timeout-minutes: 10
+                    - name: Run a one-line script
+                      run: echo Hello, world!
+              """,
+            spec -> spec.path(".github/workflows/build.yml")
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's your motivation?
A missing timeout might lead to the default of 6 hours, leading to delays in feedback and churn through CI minutes:
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes