### PR TITLE
Use Gradle Wrapper instead of Gradle binary directly

### DIFF
--- a/src/main/java/org/openrewrite/github/UseGradleWrapper.java
+++ b/src/main/java/org/openrewrite/github/UseGradleWrapper.java
@@ -1,0 +1,71 @@
+package org.openrewrite.github;
+
+import org.openrewrite.*;
+import org.openrewrite.yaml.JsonPathMatcher;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.tree.Yaml;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class UseGradleWrapper extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Use Gradle Wrapper instead of Gradle binary directly";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace calls to `gradle` with calls to `gradlew` (Gradle Wrapper) in any `.github/workflows/*.yml` file.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        final JsonPathMatcher run = new JsonPathMatcher("$.jobs..run");
+        final JsonPathMatcher runsOn = new JsonPathMatcher("$.jobs..runs-on");
+
+        return Preconditions.check(
+                new FindSourceFiles(".github/workflows/*.yml"),
+                new YamlIsoVisitor<ExecutionContext>() {
+                    private Optional<String> newExecutable = Optional.empty();
+
+                    @Override
+                    public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext executionContext) {
+                        Yaml.Mapping.Entry ret = super.visitMappingEntry(entry, executionContext);
+                        if (runsOn.matches(getCursor())) {
+                            if (ret.getValue() instanceof Yaml.Scalar) {
+                                String runsOn = ((Yaml.Scalar) ret.getValue()).getValue();
+                                if (runsOn.startsWith("ubuntu-") || runsOn.startsWith("macos-")) {
+                                    newExecutable = Optional.of("./gradlew ");
+                                } else if (runsOn.startsWith("windows-")) {
+                                    newExecutable = Optional.of("gradlew ");
+                                }
+                            }
+                        }
+                        if (newExecutable.isPresent() && run.matches(getCursor())) {
+                            if (ret.getValue() instanceof Yaml.Scalar) {
+                                Yaml.Scalar scalar = (Yaml.Scalar) ret.getValue();
+                                String replaced = Arrays.stream(scalar.getValue().split("\n"))
+                                        .map(line -> {
+                                            if (line.startsWith("gradle ")) {
+                                                return line.replaceAll("^gradle ", newExecutable.get());
+                                            } else {
+                                                return line;
+                                            }
+                                        }).collect(Collectors.joining("\n"));
+                                boolean changed = ! replaced.equals(scalar.getValue());
+                                if (changed) {
+                                    return ret.withValue(scalar.withValue(replaced));
+                                } else {
+                                    return ret;
+                                }
+                            }
+                        }
+                        return ret;
+                    }
+                }
+                );
+    }
+}

--- a/src/main/java/org/openrewrite/github/UseGradleWrapper.java
+++ b/src/main/java/org/openrewrite/github/UseGradleWrapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.github;
 
 import org.openrewrite.*;

--- a/src/test/java/org/openrewrite/github/UseGradleWrapperTest.java
+++ b/src/test/java/org/openrewrite/github/UseGradleWrapperTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.github;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/github/UseGradleWrapperTest.java
+++ b/src/test/java/org/openrewrite/github/UseGradleWrapperTest.java
@@ -1,0 +1,129 @@
+package org.openrewrite.github;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.yaml.Assertions.yaml;
+
+public class UseGradleWrapperTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new UseGradleWrapper());
+    }
+
+    @DocumentExample
+    @Test
+    void simpleGradlew() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+                    name: Java CI
+
+                    on: [push]
+
+                    jobs:
+                      build:
+                        runs-on: ubuntu-latest
+                        steps:
+                          - name: Build with gradle
+                            run: gradle test
+              """,
+            """
+                    name: Java CI
+
+                    on: [push]
+
+                    jobs:
+                      build:
+                        runs-on: ubuntu-latest
+                        steps:
+                          - name: Build with gradle
+                            run: ./gradlew test
+              """,
+            spec -> spec.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void windows() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+                    name: Java CI
+
+                    on: [push]
+
+                    jobs:
+                      build:
+                        runs-on: windows-2019
+                        steps:
+                          - name: Build with gradle
+                            run: gradle test
+              """,
+            """
+                    name: Java CI
+
+                    on: [push]
+
+                    jobs:
+                      build:
+                        runs-on: windows-2019
+                        steps:
+                          - name: Build with gradle
+                            run: gradlew test
+              """,
+            spec -> spec.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void noChangeIfUnknownRunner() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+                    name: Java CI
+
+                    on: [push]
+
+                    jobs:
+                      build:
+                        runs-on: as-400
+                        steps:
+                          - name: Build with gradle
+                            run: gradle test
+              """,
+            spec -> spec.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void noChangeIfGradleIsMentionedInSomeOtherWay() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+                    name: Java CI
+
+                    on: [push]
+
+                    jobs:
+                      build:
+                        runs-on: ubuntu-latest
+                        steps:
+                          - name: Build with gradle
+                            run: echo I would run gradle test, but I do something else
+              """,
+            spec -> spec.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+}


### PR DESCRIPTION
## What's changed?
Adding a new recipe for using `gradlew` (Gradle Wrapper) instead of calling the Gradle binary directly.

## What's your motivation?
Closes #58

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
