### PR TITLE
feat: add recipe for upgrading to `slack-github-action` v2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,3 +10,12 @@ dependencies {
     implementation("org.openrewrite:rewrite-yaml:${rewriteVersion}")
     runtimeOnly("com.fasterxml.jackson.core:jackson-core")
 }
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+tasks.named<JavaCompile>("compileJava") {
+    options.release.set(8)
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,12 +10,3 @@ dependencies {
     implementation("org.openrewrite:rewrite-yaml:${rewriteVersion}")
     runtimeOnly("com.fasterxml.jackson.core:jackson-core")
 }
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-}
-
-tasks.named<JavaCompile>("compileJava") {
-    options.release.set(8)
-}

--- a/src/main/java/org/openrewrite/github/UpgradeSlackNotificationVersion2.java
+++ b/src/main/java/org/openrewrite/github/UpgradeSlackNotificationVersion2.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.github;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.yaml.ChangeValue;
+import org.openrewrite.yaml.DeleteKey;
+import org.openrewrite.yaml.MergeYaml;
+import org.openrewrite.yaml.YamlVisitor;
+import org.openrewrite.yaml.search.FindKey;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.Objects;
+import java.util.Set;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class UpgradeSlackNotificationVersion2 extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Upgrade `slackapi/slack-github-action`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Update the Slack GitHub Action to use version 2.0.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new FindSourceFiles(".github/workflows/*.yml"), new UpgradeSlackNotificationActionVisitor());
+    }
+
+    @AllArgsConstructor
+    private static class UpgradeSlackNotificationActionVisitor extends YamlVisitor<ExecutionContext> {
+        private static final String jsonPath = "$..steps[?(@.uses =~ 'slackapi/slack-github-action@v1.*')]";
+
+        @Override
+        public Yaml visitDocuments(Yaml.Documents documents, ExecutionContext ctx) {
+            Yaml.Documents d = documents;
+            Set<Yaml> slackAction = FindKey.find(documents, jsonPath);
+
+            if (slackAction.isEmpty()) {
+                return documents;
+            }
+
+            Yaml slackActionFragment = slackAction.iterator().next();
+            Set<Yaml> token = FindKey.find(slackActionFragment, "$.env.SLACK_BOT_TOKEN");
+            Set<Yaml> channel = FindKey.find(slackActionFragment, "$.with.channel-id");
+            Set<Yaml> message = FindKey.find(slackActionFragment, "$.with.slack-message");
+
+            if (token.isEmpty() || channel.isEmpty() || message.isEmpty()) {
+                return documents;
+            }
+
+            String slackToken = ((Yaml.Scalar) ((Yaml.Mapping.Entry) token.iterator().next()).getValue()).getValue();
+            String channelName = ((Yaml.Scalar) ((Yaml.Mapping.Entry) channel.iterator().next()).getValue()).getValue();
+            String messageText = ((Yaml.Scalar) ((Yaml.Mapping.Entry) message.iterator().next()).getValue()).getValue();
+
+            d = (Yaml.Documents) new MergeYaml(jsonPath,
+                    "with:\n" +
+                            "  method: chat.postMessage\n" +
+                            "  token: " + slackToken + "\n" +
+                            "  payload: |\n" +
+                            "            channel: \"" + channelName + "\"\n" +
+                            "            text: \"" + messageText + "\"\n",
+                    false, null, null)
+                    .getVisitor().visitNonNull(d, ctx);
+
+            d = (Yaml.Documents) new DeleteKey(jsonPath + ".with.channel-id", null)
+                    .getVisitor().visitNonNull(d, ctx);
+            d = (Yaml.Documents) new DeleteKey(jsonPath + ".with.slack-message", null)
+                    .getVisitor().visitNonNull(d, ctx);
+            d = (Yaml.Documents) new DeleteKey(jsonPath + ".env.SLACK_BOT_TOKEN", null)
+                    .getVisitor().visitNonNull(d, ctx);
+
+            d = (Yaml.Documents) new ChangeValue(jsonPath + ".uses", "slackapi/slack-github-action@v2.0.0", null)
+                    .getVisitor().visitNonNull(d, ctx);
+
+            return autoFormat(d, ctx, Objects.requireNonNull(getCursor().getParent()));
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/github/UpgradeSlackNotificationVersion2.java
+++ b/src/main/java/org/openrewrite/github/UpgradeSlackNotificationVersion2.java
@@ -15,9 +15,6 @@
  */
 package org.openrewrite.github;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.yaml.ChangeValue;
 import org.openrewrite.yaml.DeleteKey;
@@ -28,6 +25,9 @@ import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.Objects;
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -75,11 +75,11 @@ public class UpgradeSlackNotificationVersion2 extends Recipe {
 
             d = (Yaml.Documents) new MergeYaml(jsonPath,
                     "with:\n" +
-                            "  method: chat.postMessage\n" +
-                            "  token: " + slackToken + "\n" +
-                            "  payload: |\n" +
-                            "            channel: \"" + channelName + "\"\n" +
-                            "            text: \"" + messageText + "\"\n",
+                    "  method: chat.postMessage\n" +
+                    "  token: " + slackToken + "\n" +
+                    "  payload: |\n" +
+                    "            channel: \"" + channelName + "\"\n" +
+                    "            text: \"" + messageText + "\"\n",
                     false, null, null)
                     .getVisitor().visitNonNull(d, ctx);
 

--- a/src/main/java/org/openrewrite/github/UpgradeSlackNotificationVersion2.java
+++ b/src/main/java/org/openrewrite/github/UpgradeSlackNotificationVersion2.java
@@ -13,23 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * Copyright 2024 the original author or authors.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p>
- * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.openrewrite.github;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
@@ -58,54 +44,56 @@ public class UpgradeSlackNotificationVersion2 extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new FindSourceFiles(".github/workflows/*.yml"), new YamlVisitor<ExecutionContext>() {
-            private final String jsonPath = "$..steps[?(@.uses =~ 'slackapi/slack-github-action@v1.*')]";
-
-            @Override
-            public Yaml visitDocuments(Yaml.Documents documents, ExecutionContext ctx) {
-                Yaml.Documents d = documents;
-                Set<Yaml> slackAction = FindKey.find(documents, jsonPath);
-
-                if (slackAction.isEmpty()) {
-                    return documents;
-                }
-
-                Yaml slackActionFragment = slackAction.iterator().next();
-                Set<Yaml> token = FindKey.find(slackActionFragment, "$.env.SLACK_BOT_TOKEN");
-                Set<Yaml> channel = FindKey.find(slackActionFragment, "$.with.channel-id");
-                Set<Yaml> message = FindKey.find(slackActionFragment, "$.with.slack-message");
-
-                if (token.isEmpty() || channel.isEmpty() || message.isEmpty()) {
-                    return documents;
-                }
-
-                String slackToken = ((Yaml.Scalar) ((Yaml.Mapping.Entry) token.iterator().next()).getValue()).getValue();
-                String channelName = ((Yaml.Scalar) ((Yaml.Mapping.Entry) channel.iterator().next()).getValue()).getValue();
-                String messageText = ((Yaml.Scalar) ((Yaml.Mapping.Entry) message.iterator().next()).getValue()).getValue();
-
-                d = (Yaml.Documents) new MergeYaml(jsonPath,
-                        "with:\n" +
-                        "  method: chat.postMessage\n" +
-                        "  token: " + slackToken + "\n" +
-                        "  payload: |\n" +
-                        "            channel: \"" + channelName + "\"\n" +
-                        "            text: \"" + messageText + "\"\n",
-                        false, null, null)
-                        .getVisitor().visitNonNull(d, ctx);
-
-                d = (Yaml.Documents) new DeleteKey(jsonPath + ".with.channel-id", null)
-                        .getVisitor().visitNonNull(d, ctx);
-                d = (Yaml.Documents) new DeleteKey(jsonPath + ".with.slack-message", null)
-                        .getVisitor().visitNonNull(d, ctx);
-                d = (Yaml.Documents) new DeleteKey(jsonPath + ".env.SLACK_BOT_TOKEN", null)
-                        .getVisitor().visitNonNull(d, ctx);
-
-                d = (Yaml.Documents) new ChangeValue(jsonPath + ".uses", "slackapi/slack-github-action@v2.0.0", null)
-                        .getVisitor().visitNonNull(d, ctx);
-
-                return autoFormat(d, ctx, Objects.requireNonNull(getCursor().getParent()));
-            }
-        });
+        return Preconditions.check(new FindSourceFiles(".github/workflows/*.yml"), new UpgradeSlackNotificationActionVisitor());
     }
 
+    @AllArgsConstructor
+    private static class UpgradeSlackNotificationActionVisitor extends YamlVisitor<ExecutionContext> {
+        private static final String jsonPath = "$..steps[?(@.uses =~ 'slackapi/slack-github-action@v1.*')]";
+
+        @Override
+        public Yaml visitDocuments(Yaml.Documents documents, ExecutionContext ctx) {
+            Yaml.Documents d = documents;
+            Set<Yaml> slackAction = FindKey.find(documents, jsonPath);
+
+            if (slackAction.isEmpty()) {
+                return documents;
+            }
+
+            Yaml slackActionFragment = slackAction.iterator().next();
+            Set<Yaml> token = FindKey.find(slackActionFragment, "$.env.SLACK_BOT_TOKEN");
+            Set<Yaml> channel = FindKey.find(slackActionFragment, "$.with.channel-id");
+            Set<Yaml> message = FindKey.find(slackActionFragment, "$.with.slack-message");
+
+            if (token.isEmpty() || channel.isEmpty() || message.isEmpty()) {
+                return documents;
+            }
+
+            String slackToken = ((Yaml.Scalar) ((Yaml.Mapping.Entry) token.iterator().next()).getValue()).getValue();
+            String channelName = ((Yaml.Scalar) ((Yaml.Mapping.Entry) channel.iterator().next()).getValue()).getValue();
+            String messageText = ((Yaml.Scalar) ((Yaml.Mapping.Entry) message.iterator().next()).getValue()).getValue();
+
+            d = (Yaml.Documents) new MergeYaml(jsonPath,
+                    "with:\n" +
+                            "  method: chat.postMessage\n" +
+                            "  token: " + slackToken + "\n" +
+                            "  payload: |\n" +
+                            "            channel: \"" + channelName + "\"\n" +
+                            "            text: \"" + messageText + "\"\n",
+                    false, null, null)
+                    .getVisitor().visitNonNull(d, ctx);
+
+            d = (Yaml.Documents) new DeleteKey(jsonPath + ".with.channel-id", null)
+                    .getVisitor().visitNonNull(d, ctx);
+            d = (Yaml.Documents) new DeleteKey(jsonPath + ".with.slack-message", null)
+                    .getVisitor().visitNonNull(d, ctx);
+            d = (Yaml.Documents) new DeleteKey(jsonPath + ".env.SLACK_BOT_TOKEN", null)
+                    .getVisitor().visitNonNull(d, ctx);
+
+            d = (Yaml.Documents) new ChangeValue(jsonPath + ".uses", "slackapi/slack-github-action@v2.0.0", null)
+                    .getVisitor().visitNonNull(d, ctx);
+
+            return autoFormat(d, ctx, Objects.requireNonNull(getCursor().getParent()));
+        }
+    }
 }

--- a/src/main/java/org/openrewrite/github/UpgradeSlackNotificationVersion2.java
+++ b/src/main/java/org/openrewrite/github/UpgradeSlackNotificationVersion2.java
@@ -13,9 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.github;
-
-import lombok.AllArgsConstructor;
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ package org.openrewrite.github;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;

--- a/src/main/java/org/openrewrite/github/UpgradeSlackNotificationVersion2.java
+++ b/src/main/java/org/openrewrite/github/UpgradeSlackNotificationVersion2.java
@@ -41,6 +41,9 @@ import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.Objects;
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 
 @Value
 @EqualsAndHashCode(callSuper = false)

--- a/src/test/java/org/openrewrite/github/UpgradeSlackNotificationVersion2Test.java
+++ b/src/test/java/org/openrewrite/github/UpgradeSlackNotificationVersion2Test.java
@@ -15,7 +15,9 @@
  */
 package org.openrewrite.github;
 
+
 import org.junit.jupiter.api.Test;
+
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/src/test/java/org/openrewrite/github/UpgradeSlackNotificationVersion2Test.java
+++ b/src/test/java/org/openrewrite/github/UpgradeSlackNotificationVersion2Test.java
@@ -17,7 +17,6 @@ package org.openrewrite.github;
 
 
 import org.junit.jupiter.api.Test;
-
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -38,32 +37,32 @@ class UpgradeSlackNotificationVersion2Test implements RewriteTest {
           // language=yaml
           yaml(
             """
-            jobs:
-              build:
-                steps:
-                  - name: Send notification on error
-                    if: failure() && inputs.send-notification
-                    uses: slackapi/slack-github-action@v1.27.0
-                    with:
-                      channel-id: "##foo-alerts"
-                      slack-message: ":boom: Unable run dependency check on: <${{ steps.get_failed_check_link.outputs.failed-check-link }}|${{ inputs.organization }}/${{ inputs.repository }}>"
-                    env:
-                      SLACK_BOT_TOKEN: ${{ secrets.SLACK_MORTY_BOT_TOKEN }}
-            """,
+              jobs:
+                build:
+                  steps:
+                    - name: Send notification on error
+                      if: failure() && inputs.send-notification
+                      uses: slackapi/slack-github-action@v1.27.0
+                      with:
+                        channel-id: "##foo-alerts"
+                        slack-message: ":boom: Unable run dependency check on: <${{ steps.get_failed_check_link.outputs.failed-check-link }}|${{ inputs.organization }}/${{ inputs.repository }}>"
+                      env:
+                        SLACK_BOT_TOKEN: ${{ secrets.SLACK_MORTY_BOT_TOKEN }}
+              """,
             """
-            jobs:
-              build:
-                steps:
-                  - name: Send notification on error
-                    if: failure() && inputs.send-notification
-                    uses: slackapi/slack-github-action@v2.0.0
-                    with:
-                      method: chat.postMessage
-                      token: ${{ secrets.SLACK_MORTY_BOT_TOKEN }}
-                      payload: |
-                        channel: "##foo-alerts"
-                        text: ":boom: Unable run dependency check on: <${{ steps.get_failed_check_link.outputs.failed-check-link }}|${{ inputs.organization }}/${{ inputs.repository }}>"
-            """,
+              jobs:
+                build:
+                  steps:
+                    - name: Send notification on error
+                      if: failure() && inputs.send-notification
+                      uses: slackapi/slack-github-action@v2.0.0
+                      with:
+                        method: chat.postMessage
+                        token: ${{ secrets.SLACK_MORTY_BOT_TOKEN }}
+                        payload: |
+                          channel: "##foo-alerts"
+                          text: ":boom: Unable run dependency check on: <${{ steps.get_failed_check_link.outputs.failed-check-link }}|${{ inputs.organization }}/${{ inputs.repository }}>"
+              """,
             spec -> spec.path(".github/workflows/ci.yml")));
     }
 }

--- a/src/test/java/org/openrewrite/github/UpgradeSlackNotificationVersion2Test.java
+++ b/src/test/java/org/openrewrite/github/UpgradeSlackNotificationVersion2Test.java
@@ -15,8 +15,8 @@
  */
 package org.openrewrite.github;
 
-
 import org.junit.jupiter.api.Test;
+
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/src/test/java/org/openrewrite/github/UpgradeSlackNotificationVersion2Test.java
+++ b/src/test/java/org/openrewrite/github/UpgradeSlackNotificationVersion2Test.java
@@ -15,11 +15,11 @@
  */
 package org.openrewrite.github;
 
-import org.junit.jupiter.api.Test;
-
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import org.junit.jupiter.api.Test;
 
 import static org.openrewrite.yaml.Assertions.yaml;
 

--- a/src/test/java/org/openrewrite/github/UpgradeSlackNotificationVersion2Test.java
+++ b/src/test/java/org/openrewrite/github/UpgradeSlackNotificationVersion2Test.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.github;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.yaml.Assertions.yaml;
+
+class UpgradeSlackNotificationVersion2Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new UpgradeSlackNotificationVersion2());
+    }
+
+    @DocumentExample
+    @Test
+    void updatesVersion2() {
+        rewriteRun(
+          // language=yaml
+          yaml(
+            """
+            jobs:
+              build:
+                steps:
+                  - name: Send notification on error
+                    if: failure() && inputs.send-notification
+                    uses: slackapi/slack-github-action@v1.27.0
+                    with:
+                      channel-id: "##foo-alerts"
+                      slack-message: ":boom: Unable run dependency check on: <${{ steps.get_failed_check_link.outputs.failed-check-link }}|${{ inputs.organization }}/${{ inputs.repository }}>"
+                    env:
+                      SLACK_BOT_TOKEN: ${{ secrets.SLACK_MORTY_BOT_TOKEN }}
+            """,
+            """
+            jobs:
+              build:
+                steps:
+                  - name: Send notification on error
+                    if: failure() && inputs.send-notification
+                    uses: slackapi/slack-github-action@v2.0.0
+                    with:
+                      method: chat.postMessage
+                      token: ${{ secrets.SLACK_MORTY_BOT_TOKEN }}
+                      payload: |
+                        channel: "##foo-alerts"
+                        text: ":boom: Unable run dependency check on: <${{ steps.get_failed_check_link.outputs.failed-check-link }}|${{ inputs.organization }}/${{ inputs.repository }}>"
+            """,
+            spec -> spec.path(".github/workflows/ci.yml")));
+    }
+}


### PR DESCRIPTION
featured breaking changes in how messages were posted to slack. this handles the second scenario
defined in their repository.
