### PR TITLE
Fixing markdown for link

### DIFF
--- a/src/main/java/org/openrewrite/github/PreferTemurinDistributions.java
+++ b/src/main/java/org/openrewrite/github/PreferTemurinDistributions.java
@@ -34,7 +34,7 @@ public class PreferTemurinDistributions extends Recipe {
 
     @Override
     public String getDescription() {
-        return "[Host runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources/) include Temurin by default as part of the (hosted tool cache)(https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#hosted-tool-cache). " +
+        return "[Host runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources/) include Temurin by default as part of the [hosted tool cache](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#hosted-tool-cache). " +
                "Using Temurin speeds up builds as there is no need to download and configure the Java SDK with every build.";
     }
 


### PR DESCRIPTION
## What's changed?

Minor thing. Fixing the markdown syntax in recipe description.

## What's your motivation?
It's broken right now.

<img width="1642" height="419" alt="image" src="https://github.com/user-attachments/assets/86cc4c14-6255-4750-9e76-e1df5ff49016" />
