### PR TITLE
`RemoveUnusedWorkflowDispatchInputs` - Handling alternate syntax for inputs

### DIFF
--- a/src/main/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputs.java
+++ b/src/main/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputs.java
@@ -34,7 +34,7 @@ import static org.openrewrite.Tree.randomId;
 
 public class RemoveUnusedWorkflowDispatchInputs extends Recipe {
 
-    private static final Pattern INPUT_USAGE_PATTERN = Pattern.compile("github[.]event[.]inputs[.](\\w+)");
+    private static final Pattern INPUT_USAGE_PATTERN = Pattern.compile("(?:github *[.] *event *[.] *inputs *[.] *(\\w+)|inputs *[.] *(\\w+))");
     private static final JsonPathMatcher WORKFLOW_DISPATCH_INPUTS_MATCHER = new JsonPathMatcher("$.on.workflow_dispatch.inputs");
 
     @Override
@@ -86,7 +86,10 @@ public class RemoveUnusedWorkflowDispatchInputs extends Recipe {
                         // and no harm is done in such a case.
                         Matcher matcher = INPUT_USAGE_PATTERN.matcher(value);
                         while (matcher.find()) {
-                            usedInputs.add(matcher.group(1));
+                            String inputName = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+                            if (inputName != null) {
+                                usedInputs.add(inputName);
+                            }
                         }
 
                         return super.visitScalar(scalar, ctx);

--- a/src/test/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputsTest.java
+++ b/src/test/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputsTest.java
@@ -62,7 +62,7 @@ class RemoveUnusedWorkflowDispatchInputsTest implements RewriteTest {
                     - name: Another step
                       run: echo "Just a step without input reference"
                     - name: Step 3
-                      if: github.event.inputs.usedInGithubActionSyntax == 'true'
+                      if: inputs . usedInGithubActionSyntax == 'true'
                       run: echo "Conditional step"
               """,
             """
@@ -85,7 +85,7 @@ class RemoveUnusedWorkflowDispatchInputsTest implements RewriteTest {
                     - name: Another step
                       run: echo "Just a step without input reference"
                     - name: Step 3
-                      if: github.event.inputs.usedInGithubActionSyntax == 'true'
+                      if: inputs . usedInGithubActionSyntax == 'true'
                       run: echo "Conditional step"
               """,
             spec -> spec.path(".github/workflows/test.yml")


### PR DESCRIPTION
## What's changed?

A fix for the recipe called `RemoveUnusedWorkflowDispatchInputs` added in #136.

## What's your motivation?

Provide handling for what is reportedly a valid alternative syntax to refer to workflow inputs - i.e. `inputs.something` vs. `github.event.inputs.something` which is already supported.
