### PR TITLE
`RemoveUnusedWorkflowDispatchInput` - safety check against empty workflow_dispatch

### DIFF
--- a/src/main/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputs.java
+++ b/src/main/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputs.java
@@ -96,7 +96,7 @@ public class RemoveUnusedWorkflowDispatchInputs extends Recipe {
                     }
                 }.visit(document, ctx);
 
-                if (definedInputs.size() == usedInputs.size()) {
+                if (definedInputs.size() == usedInputs.size() || definedInputs.isEmpty()) {
                     return document;
                 }
 
@@ -119,7 +119,7 @@ public class RemoveUnusedWorkflowDispatchInputs extends Recipe {
                     public @Nullable Yaml postVisit(Yaml tree, ExecutionContext ctx) {
                         if (tree instanceof Yaml.Mapping.Entry) {
                             Yaml.Mapping.Entry entry = (Yaml.Mapping.Entry) tree;
-                            if ("workflow_dispatch".equals(entry.getKey().getValue())) {
+                            if ("workflow_dispatch".equals(entry.getKey().getValue()) && entry.getValue() instanceof Yaml.Mapping) {
                                 Yaml.Mapping inputs = (Yaml.Mapping) entry.getValue();
                                 if (inputs.getEntries().size() == 1) {
                                     Yaml.Mapping.Entry inputsEntry = inputs.getEntries().get(0);

--- a/src/test/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputsTest.java
+++ b/src/test/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputsTest.java
@@ -199,4 +199,18 @@ class RemoveUnusedWorkflowDispatchInputsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNothingWhenWorkflowDispatchIsEmpty() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+              on:
+                workflow_dispatch:
+              """,
+            spec -> spec.path(".github/workflows/stub.yml")
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Another follow-up on #136 after running this against real code in practice.
Adding a safety check against empty workflow_dispatch entries.

## What's your motivation?

To fix the error triggered on recipe runs:
```
java.lang.ClassCastException: class org.openrewrite.yaml.tree.Yaml$Scalar cannot be cast to class org.openrewrite.yaml.tree.Yaml$Mapping (org.openrewrite.yaml.tree.Yaml$Scalar and org.openrewrite.yaml.tree.Yaml$Mapping are in unnamed module of loader 'app')
  org.openrewrite.github.RemoveUnusedWorkflowDispatchInputs$1$2.postVisit(RemoveUnusedWorkflowDispatchInputs.java:123)
  org.openrewrite.github.RemoveUnusedWorkflowDispatchInputs$1$2.postVisit(RemoveUnusedWorkflowDispatchInputs.java:103)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:248)
[...]
```
