### PR TITLE
`RemoveUnusedWorkflowDispatchInputs` - amend the detection of input names

### DIFF
--- a/src/main/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputs.java
+++ b/src/main/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputs.java
@@ -34,7 +34,7 @@ import static org.openrewrite.Tree.randomId;
 
 public class RemoveUnusedWorkflowDispatchInputs extends Recipe {
 
-    private static final Pattern INPUT_USAGE_PATTERN = Pattern.compile("(?:github *[.] *event *[.] *inputs *[.] *(\\w+)|inputs *[.] *(\\w+))");
+    private static final Pattern INPUT_USAGE_PATTERN = Pattern.compile("(?:github *[.] *event *[.] *inputs *[.] *([A-Za-z_][A-Za-z0-9_-]*)|inputs *[.] *([A-Za-z_][A-Za-z0-9_-]*))");
     private static final JsonPathMatcher WORKFLOW_DISPATCH_INPUTS_MATCHER = new JsonPathMatcher("$.on.workflow_dispatch.inputs");
 
     @Override

--- a/src/test/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputsTest.java
+++ b/src/test/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputsTest.java
@@ -102,7 +102,7 @@ class RemoveUnusedWorkflowDispatchInputsTest implements RewriteTest {
               on:
                 workflow_dispatch:
                   inputs:
-                    usedInScript:
+                    usedInScript436:
                       description: 'Used in multiline script'
                     alsoUsedInScript:
                       description: 'Also used in multiline script'
@@ -115,7 +115,7 @@ class RemoveUnusedWorkflowDispatchInputsTest implements RewriteTest {
                   steps:
                     - run: |
                         echo "Starting deployment"
-                        echo "Input value: ${{ github.event.inputs.usedInScript }}"
+                        echo "Input value: ${{ github.event.inputs.usedInScript436 }}"
                         echo "Another input value: ${{ github.event.inputs.alsoUsedInScript }}"
                         echo "Done"
               """,
@@ -123,7 +123,7 @@ class RemoveUnusedWorkflowDispatchInputsTest implements RewriteTest {
               on:
                 workflow_dispatch:
                   inputs:
-                    usedInScript:
+                    usedInScript436:
                       description: 'Used in multiline script'
                     alsoUsedInScript:
                       description: 'Also used in multiline script'
@@ -134,7 +134,7 @@ class RemoveUnusedWorkflowDispatchInputsTest implements RewriteTest {
                   steps:
                     - run: |
                         echo "Starting deployment"
-                        echo "Input value: ${{ github.event.inputs.usedInScript }}"
+                        echo "Input value: ${{ github.event.inputs.usedInScript436 }}"
                         echo "Another input value: ${{ github.event.inputs.alsoUsedInScript }}"
                         echo "Done"
               """,

--- a/src/test/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputsTest.java
+++ b/src/test/java/org/openrewrite/github/RemoveUnusedWorkflowDispatchInputsTest.java
@@ -41,10 +41,10 @@ class RemoveUnusedWorkflowDispatchInputsTest implements RewriteTest {
               on:
                 workflow_dispatch:
                   inputs:
-                    usedInput:
+                    used-input:
                       description: 'This input is used'
                       required: true
-                    unusedInput:
+                    unused_input:
                       description: 'This input is not used anywhere'
                       required: false
                     anotherUnusedInput:
@@ -58,7 +58,7 @@ class RemoveUnusedWorkflowDispatchInputsTest implements RewriteTest {
                   runs-on: ubuntu-latest
                   steps:
                     - name: Use input
-                      run: echo "Used input - ${{ github.event.inputs.usedInput }}"
+                      run: echo "Used input - ${{ github.event.inputs.used-input }}"
                     - name: Another step
                       run: echo "Just a step without input reference"
                     - name: Step 3
@@ -70,7 +70,7 @@ class RemoveUnusedWorkflowDispatchInputsTest implements RewriteTest {
               on:
                 workflow_dispatch:
                   inputs:
-                    usedInput:
+                    used-input:
                       description: 'This input is used'
                       required: true
                     usedInGithubActionSyntax:
@@ -81,7 +81,7 @@ class RemoveUnusedWorkflowDispatchInputsTest implements RewriteTest {
                   runs-on: ubuntu-latest
                   steps:
                     - name: Use input
-                      run: echo "Used input - ${{ github.event.inputs.usedInput }}"
+                      run: echo "Used input - ${{ github.event.inputs.used-input }}"
                     - name: Another step
                       run: echo "Just a step without input reference"
                     - name: Step 3


### PR DESCRIPTION
## What's changed?

Amending the recently added `RemoveUnusedWorkflowDispatchInputs` to better discover input names. In practice these often contain a hyphen character `-`.

## What's your motivation?

Avoid false positives of not detecting proper usage of an input. Leading to excessive removal of input.