### PR TITLE
Fix AddCronTrigger Jackson deserialization

### DIFF
--- a/src/main/java/org/openrewrite/github/AddCronTrigger.java
+++ b/src/main/java/org/openrewrite/github/AddCronTrigger.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.github;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +56,7 @@ public class AddCronTrigger extends Recipe {
         this.workflowFileMatcher = workflowFileMatcher;
     }
 
+    @JsonCreator
     public AddCronTrigger(String cron, @Nullable String fileMatcher) {
         this(cron, fileMatcher, ThreadLocalRandom.current());
     }


### PR DESCRIPTION
## Summary
- Add `@JsonCreator` to `AddCronTrigger`'s public constructor so Jackson can deserialize it
- Fixes all 15 `AddCronTriggerTest` failures on main introduced by the Lombok Best Practices commit (c51d7fe)
- Matches the pattern already used by `ForbiddenUsesRecipe`

## Test plan
- [x] `./gradlew test --tests "org.openrewrite.github.AddCronTriggerTest"` passes locally