### PR TITLE
feat(dependabot-cooldown): Add the ability to exclude ecosystems

### DIFF
--- a/src/main/java/org/openrewrite/github/AddDependabotCooldown.java
+++ b/src/main/java/org/openrewrite/github/AddDependabotCooldown.java
@@ -84,6 +84,13 @@ public class AddDependabotCooldown extends Recipe {
     @Nullable
     List<String> exclude;
 
+    @Option(displayName = "Exclude ecosystems",
+            description = "List of ecosystems to be excluded",
+            example = "github-actions",
+            required = false)
+    @Nullable
+    List<String> excludeEcosystems;
+
     String displayName = "Add cooldown periods to Dependabot configuration";
 
     String description = "Adds a `cooldown` section to each update configuration in Dependabot files. " +
@@ -148,6 +155,13 @@ public class AddDependabotCooldown extends Recipe {
                 Yaml.Mapping m = super.visitMapping(mapping, ctx);
 
                 if (Boolean.TRUE.equals(getCursor().pollMessage("ADD_COOLDOWN"))) {
+                    final boolean ecosystemIsExcluded = excludeEcosystems != null && m.getEntries()
+                            .stream()
+                            .anyMatch(entry -> "package-ecosystem".equals(entry.getKey().getValue())
+                            && entry.getValue() instanceof Yaml.Scalar && excludeEcosystems.contains(((Yaml.Scalar)entry.getValue()).getValue()));
+                    if (ecosystemIsExcluded) {
+                        return m;
+                    }
                     // Check if cooldown already exists
                     boolean hasCooldown = m.getEntries().stream()
                             .anyMatch(entry -> "cooldown".equals(entry.getKey().getValue()));

--- a/src/test/java/org/openrewrite/github/AddDependabotCooldownTest.java
+++ b/src/test/java/org/openrewrite/github/AddDependabotCooldownTest.java
@@ -29,7 +29,7 @@ class AddDependabotCooldownTest implements RewriteTest {
     @Test
     void addCooldownWithDefaultDays() {
         rewriteRun(
-          spec -> spec.recipe(new AddDependabotCooldown(null, null, null, null, null, null)),
+          spec -> spec.recipe(new AddDependabotCooldown(null, null, null, null, null, null, null)),
           //language=yaml
           yaml(
             """
@@ -68,7 +68,7 @@ class AddDependabotCooldownTest implements RewriteTest {
     @Test
     void addCooldownWithCustomDays() {
         rewriteRun(
-          spec -> spec.recipe(new AddDependabotCooldown(14, null, null, null, null, null)),
+          spec -> spec.recipe(new AddDependabotCooldown(14, null, null, null, null, null, null)),
           //language=yaml
           yaml(
             """
@@ -97,7 +97,7 @@ class AddDependabotCooldownTest implements RewriteTest {
     @Test
     void cooldownAlreadyExists() {
         rewriteRun(
-          spec -> spec.recipe(new AddDependabotCooldown(7, null, null, null, null, null)),
+          spec -> spec.recipe(new AddDependabotCooldown(7, null, null, null, null, null, null)),
           //language=yaml
           yaml(
             """
@@ -118,7 +118,7 @@ class AddDependabotCooldownTest implements RewriteTest {
     @Test
     void multipleEcosystemsWithExistingOptions() {
         rewriteRun(
-          spec -> spec.recipe(new AddDependabotCooldown(null, null, null, null, null, null)),
+          spec -> spec.recipe(new AddDependabotCooldown(null, null, null, null, null, null, null)),
           //language=yaml
           yaml(
             """
@@ -163,7 +163,7 @@ class AddDependabotCooldownTest implements RewriteTest {
     @Test
     void worksWithDependabotYamlExtension() {
         rewriteRun(
-          spec -> spec.recipe(new AddDependabotCooldown(null, null, null, null, null, null)),
+          spec -> spec.recipe(new AddDependabotCooldown(null, null, null, null, null, null, null)),
           //language=yaml
           yaml(
             """
@@ -192,7 +192,7 @@ class AddDependabotCooldownTest implements RewriteTest {
     @Test
     void addsSemverSpecificCooldowns() {
         rewriteRun(
-          spec -> spec.recipe(new AddDependabotCooldown(7, 14, 7, 3, null, null)),
+          spec -> spec.recipe(new AddDependabotCooldown(7, 14, 7, 3, null, null, null)),
           //language=yaml
           yaml(
             """
@@ -225,7 +225,7 @@ class AddDependabotCooldownTest implements RewriteTest {
     void addsIncludeList() {
         rewriteRun(
           spec -> spec.recipe(new AddDependabotCooldown(7, null, null, null,
-            List.of("lodash", "react*"), null)),
+            List.of("lodash", "react*"), null, null)),
           //language=yaml
           yaml(
             """
@@ -258,7 +258,7 @@ class AddDependabotCooldownTest implements RewriteTest {
     void addsExcludeList() {
         rewriteRun(
           spec -> spec.recipe(new AddDependabotCooldown(7, null, null, null,
-            null, List.of("critical-security-package"))),
+            null, List.of("critical-security-package"), null)),
           //language=yaml
           yaml(
             """
@@ -291,7 +291,7 @@ class AddDependabotCooldownTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new AddDependabotCooldown(7, 14, 7, 3,
             List.of("lodash", "express"),
-            List.of("security-lib"))),
+            List.of("security-lib"), null)),
           //language=yaml
           yaml(
             """
@@ -328,7 +328,7 @@ class AddDependabotCooldownTest implements RewriteTest {
     @Test
     void addsToMultipleEcosystemsWithDifferentConfigurations() {
         rewriteRun(
-          spec -> spec.recipe(new AddDependabotCooldown(7, 14, null, null, null, null)),
+          spec -> spec.recipe(new AddDependabotCooldown(7, 14, null, null, null, null, null)),
           //language=yaml
           yaml(
             """
@@ -371,6 +371,120 @@ class AddDependabotCooldownTest implements RewriteTest {
                   cooldown:
                     default-days: 7
                     semver-major-days: 14
+              """,
+            spec -> spec.path(".github/dependabot.yml")
+          )
+        );
+    }
+
+    @Test
+    void addCooldownWithExcludeOneEcosystem() {
+        rewriteRun(
+          spec -> spec.recipe(new AddDependabotCooldown(9, null, null,
+            null, null, null, List.of("npm"))),
+          //language=yaml
+          yaml(
+            """
+              version: 2
+              updates:
+                - package-ecosystem: github-actions
+                  directory: /
+                  schedule:
+                    interval: daily
+                - package-ecosystem: npm
+                  directory: /
+                  schedule:
+                    interval: weekly
+                - package-ecosystem: pip
+                  directory: /
+                  schedule:
+                    interval: daily
+                - package-ecosystem: gradle
+                  directory: /
+                  schedule:
+                    interval: monthly
+              """,
+            """
+              version: 2
+              updates:
+                - package-ecosystem: github-actions
+                  directory: /
+                  schedule:
+                    interval: daily
+                  cooldown:
+                    default-days: 9
+                - package-ecosystem: npm
+                  directory: /
+                  schedule:
+                    interval: weekly
+                - package-ecosystem: pip
+                  directory: /
+                  schedule:
+                    interval: daily
+                  cooldown:
+                    default-days: 9
+                - package-ecosystem: gradle
+                  directory: /
+                  schedule:
+                    interval: monthly
+                  cooldown:
+                    default-days: 9
+              """,
+            spec -> spec.path(".github/dependabot.yml")
+          )
+        );
+    }
+
+    @Test
+    void addCooldownWithExcludeManyEcosystems() {
+        rewriteRun(
+          spec -> spec.recipe(new AddDependabotCooldown(11, null, null,
+            null, null, null, List.of("npm", "github-actions"))),
+          //language=yaml
+          yaml(
+            """
+              version: 2
+              updates:
+                - package-ecosystem: github-actions
+                  directory: /
+                  schedule:
+                    interval: daily
+                - package-ecosystem: npm
+                  directory: /
+                  schedule:
+                    interval: weekly
+                - package-ecosystem: pip
+                  directory: /
+                  schedule:
+                    interval: daily
+                - package-ecosystem: gradle
+                  directory: /
+                  schedule:
+                    interval: monthly
+              """,
+            """
+              version: 2
+              updates:
+                - package-ecosystem: github-actions
+                  directory: /
+                  schedule:
+                    interval: daily
+                - package-ecosystem: npm
+                  directory: /
+                  schedule:
+                    interval: weekly
+                - package-ecosystem: pip
+                  directory: /
+                  schedule:
+                    interval: daily
+                  cooldown:
+                    default-days: 11
+                - package-ecosystem: gradle
+                  directory: /
+                  schedule:
+                    interval: monthly
+                  cooldown:
+                    default-days: 11
               """,
             spec -> spec.path(".github/dependabot.yml")
           )


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This PR adds a new option to the `AddDependabotCooldown` recipe in order to be able to exclude one or more ecosystems from the cooldown process

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

For example I didn't find another way to exclude the ` github-actions` ecosystem from the cooldown

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
