### PR TITLE
Update Gradle action migration recipes to latest versions

### DIFF
--- a/src/main/resources/META-INF/rewrite/gradle.yml
+++ b/src/main/resources/META-INF/rewrite/gradle.yml
@@ -18,7 +18,7 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.github.gradle.RenameWrapperValidationAction
 displayName: Rename `gradle/wrapper-validation-action` to `gradle/actions/wrapper-validation`
-description: Rename the deprecated `gradle/wrapper-validation-action` to `gradle/actions/wrapper-validation@v3`.
+description: Rename the deprecated `gradle/wrapper-validation-action` to `gradle/actions/wrapper-validation@v5`.
 tags:
   - github
   - gradle
@@ -26,12 +26,12 @@ recipeList:
   - org.openrewrite.github.ChangeAction:
       oldAction: gradle/wrapper-validation-action
       newAction: gradle/actions/wrapper-validation
-      newVersion: v3
+      newVersion: v5
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.github.gradle.RenameGradleBuildActionToSetupGradle
 displayName: Rename `gradle/gradle-build-action` to `gradle/actions/setup-gradle`
-description: Rename the deprecated `gradle/gradle-build-action` to `gradle/actions/setup-gradle@v3`.
+description: Rename the deprecated `gradle/gradle-build-action` to `gradle/actions/setup-gradle@v6`.
 tags:
   - github
   - gradle
@@ -39,4 +39,4 @@ recipeList:
   - org.openrewrite.github.ChangeAction:
       oldAction: gradle/gradle-build-action
       newAction: gradle/actions/setup-gradle
-      newVersion: v3
+      newVersion: v6

--- a/src/test/java/org/openrewrite/github/ChangeActionTest.java
+++ b/src/test/java/org/openrewrite/github/ChangeActionTest.java
@@ -105,7 +105,7 @@ class ChangeActionTest implements RewriteTest {
                   steps:
                     - name: Checkout
                       uses: actions/checkout@v4
-                    - uses: gradle/actions/setup-gradle@v3
+                    - uses: gradle/actions/setup-gradle@v6
               """,
             source -> source.path(".github/workflows/ci.yml")
           )


### PR DESCRIPTION
## Summary
- Update `wrapper-validation` target version from v3 to v5 (last version before the sub-action was removed in v6)
- Update `setup-gradle` target version from v3 to v6 (latest)
- Update corresponding test expectation

Both recipes migrate from deprecated Gradle actions (`gradle/wrapper-validation-action` and `gradle/gradle-build-action`) to their replacements under `gradle/actions`.