### PR TITLE
Add allow-list option to PinGitHubActionsToSha

### DIFF
--- a/src/main/java/org/openrewrite/github/security/PinGitHubActionsToSha.java
+++ b/src/main/java/org/openrewrite/github/security/PinGitHubActionsToSha.java
@@ -65,6 +65,18 @@ public class PinGitHubActionsToSha extends ScanningRecipe<Map<String, String>> {
     @Nullable
     String githubApiToken;
 
+    @Option(displayName = "Included actions",
+            description = "Optional allow-list of actions to pin. When provided, only `uses:` references " +
+                    "matching one of these patterns are pinned; all other actions are left untouched. " +
+                    "Patterns may be `owner/repo` (exact match), `owner/*` (any repo in an org), or " +
+                    "`owner/repo/subpath` (exact match including a subpath). When omitted or empty, all " +
+                    "third-party actions (and optionally official actions, per `pinOfficialActions`) are " +
+                    "pinned.",
+            required = false,
+            example = "codecov/codecov-action")
+    @Nullable
+    List<String> includedActions;
+
     @Override
     public String getDisplayName() {
         return "Pin GitHub Actions to commit SHAs";
@@ -76,7 +88,8 @@ public class PinGitHubActionsToSha extends ScanningRecipe<Map<String, String>> {
                 "immutable commit SHAs. A static mapping of well-known actions is checked first; if " +
                 "the action is not found, the GitHub API is used to resolve the reference at recipe " +
                 "run time. By default only third-party actions are pinned; set `pinOfficialActions` " +
-                "to include actions from the `actions` and `github` organizations.";
+                "to include actions from the `actions` and `github` organizations. To pin only a " +
+                "specific allow-list of actions, set `includedActions`.";
     }
 
     @Override
@@ -111,6 +124,7 @@ public class PinGitHubActionsToSha extends ScanningRecipe<Map<String, String>> {
     public TreeVisitor<?, ExecutionContext> getVisitor(Map<String, String> knownShas) {
         boolean pinOfficial = Boolean.TRUE.equals(pinOfficialActions);
         String apiToken = githubApiToken;
+        List<String> allowList = includedActions == null ? Collections.emptyList() : includedActions;
         return Preconditions.check(
                 new IsGitHubActionsWorkflow(),
                 new YamlIsoVisitor<ExecutionContext>() {
@@ -234,8 +248,14 @@ public class PinGitHubActionsToSha extends ScanningRecipe<Map<String, String>> {
                         // Determine the org from the action path
                         String org = actionPath.contains("/") ? actionPath.substring(0, actionPath.indexOf('/')) : actionPath;
 
-                        // Skip official actions unless opted in
-                        if (!pinOfficial && OFFICIAL_ORGS.contains(org)) {
+                        if (!allowList.isEmpty()) {
+                            // Allow-list mode: only pin actions matching an entry in the list.
+                            // pinOfficialActions is bypassed — explicit allow always wins.
+                            if (!matchesAllowList(actionPath, allowList)) {
+                                return null;
+                            }
+                        } else if (!pinOfficial && OFFICIAL_ORGS.contains(org)) {
+                            // Default mode: skip official actions unless opted in
                             return null;
                         }
 
@@ -316,6 +336,44 @@ public class PinGitHubActionsToSha extends ScanningRecipe<Map<String, String>> {
                     }
                 }
         );
+    }
+
+    private static boolean matchesAllowList(String actionPath, List<String> allowList) {
+        // actionPath may be "owner/repo" or "owner/repo/subpath".
+        int firstSlash = actionPath.indexOf('/');
+        String owner = firstSlash > 0 ? actionPath.substring(0, firstSlash) : actionPath;
+        int secondSlash = actionPath.indexOf('/', firstSlash + 1);
+        String ownerRepo = secondSlash > 0 ? actionPath.substring(0, secondSlash) : actionPath;
+
+        for (String pattern : allowList) {
+            if (pattern == null) {
+                continue;
+            }
+            String p = pattern.trim();
+            if (p.isEmpty()) {
+                continue;
+            }
+            // owner/* — match any repo within the org
+            if (p.endsWith("/*")) {
+                String allowedOwner = p.substring(0, p.length() - 2);
+                if (allowedOwner.equals(owner)) {
+                    return true;
+                }
+                continue;
+            }
+            // owner/repo/subpath — exact match against the full path
+            if (p.indexOf('/') != p.lastIndexOf('/')) {
+                if (p.equals(actionPath)) {
+                    return true;
+                }
+                continue;
+            }
+            // owner/repo — match against owner/repo, ignoring any subpath on the action
+            if (p.equals(ownerRepo)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static class PinResult {

--- a/src/test/java/org/openrewrite/github/security/PinGitHubActionsToShaTest.java
+++ b/src/test/java/org/openrewrite/github/security/PinGitHubActionsToShaTest.java
@@ -20,13 +20,16 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import static org.openrewrite.yaml.Assertions.yaml;
 
 class PinGitHubActionsToShaTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new PinGitHubActionsToSha(false, null));
+        spec.recipe(new PinGitHubActionsToSha(false, null, null));
     }
 
     @DocumentExample
@@ -81,7 +84,7 @@ class PinGitHubActionsToShaTest implements RewriteTest {
     @Test
     void shouldPinOfficialActionsWhenOptedIn() {
         rewriteRun(
-          spec -> spec.recipe(new PinGitHubActionsToSha(true, null)),
+          spec -> spec.recipe(new PinGitHubActionsToSha(true, null, null)),
           yaml(
             """
               name: CI
@@ -130,7 +133,7 @@ class PinGitHubActionsToShaTest implements RewriteTest {
     @Test
     void shouldPinGitHubOrgWhenOptedIn() {
         rewriteRun(
-          spec -> spec.recipe(new PinGitHubActionsToSha(true, null)),
+          spec -> spec.recipe(new PinGitHubActionsToSha(true, null, null)),
           yaml(
             """
               name: Security
@@ -267,7 +270,7 @@ class PinGitHubActionsToShaTest implements RewriteTest {
     @Test
     void shouldPinActionWithSubpath() {
         rewriteRun(
-          spec -> spec.recipe(new PinGitHubActionsToSha(false, null)),
+          spec -> spec.recipe(new PinGitHubActionsToSha(false, null, null)),
           yaml(
             """
               name: CI
@@ -324,9 +327,218 @@ class PinGitHubActionsToShaTest implements RewriteTest {
     }
 
     @Test
+    void shouldOnlyPinAllowListedActions() {
+        rewriteRun(
+          spec -> spec.recipe(new PinGitHubActionsToSha(false, null,
+            Arrays.asList("codecov/codecov-action", "docker/login-action"))),
+          yaml(
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: codecov/codecov-action@v4
+                      name: Coverage
+                    - uses: docker/login-action@v3
+                      name: Docker login
+                    - uses: docker/setup-buildx-action@v3
+                      name: Setup Buildx (not allow-listed)
+              """,
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+                      name: Coverage
+                    - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+                      name: Docker login
+                    - uses: docker/setup-buildx-action@v3
+                      name: Setup Buildx (not allow-listed)
+              """,
+            sourceSpecs -> sourceSpecs.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void shouldSupportOrgWildcardInAllowList() {
+        rewriteRun(
+          spec -> spec.recipe(new PinGitHubActionsToSha(false, null,
+            Collections.singletonList("docker/*"))),
+          yaml(
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: docker/login-action@v3
+                      name: Docker login
+                    - uses: docker/setup-buildx-action@v3
+                      name: Setup Buildx
+                    - uses: codecov/codecov-action@v4
+                      name: Not in docker org
+              """,
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+                      name: Docker login
+                    - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+                      name: Setup Buildx
+                    - uses: codecov/codecov-action@v4
+                      name: Not in docker org
+              """,
+            sourceSpecs -> sourceSpecs.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void allowListMatchesActionWithSubpathByOwnerRepo() {
+        rewriteRun(
+          spec -> spec.recipe(new PinGitHubActionsToSha(false, null,
+            Collections.singletonList("gradle/actions"))),
+          yaml(
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: gradle/actions/setup-gradle@v3
+                      name: Setup Gradle
+              """,
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3
+                      name: Setup Gradle
+              """,
+            sourceSpecs -> sourceSpecs.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void allowListWithSubpathPatternIsExact() {
+        rewriteRun(
+          spec -> spec.recipe(new PinGitHubActionsToSha(false, null,
+            Collections.singletonList("gradle/actions/setup-gradle"))),
+          yaml(
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: gradle/actions/setup-gradle@v3
+                      name: Allowed
+                    - uses: gradle/actions/wrapper-validation@v3
+                      name: Different subpath, not allow-listed
+              """,
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3
+                      name: Allowed
+                    - uses: gradle/actions/wrapper-validation@v3
+                      name: Different subpath, not allow-listed
+              """,
+            sourceSpecs -> sourceSpecs.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void allowListPinsOfficialActionWithoutPinOfficialFlag() {
+        rewriteRun(
+          spec -> spec.recipe(new PinGitHubActionsToSha(false, null,
+            Collections.singletonList("actions/checkout"))),
+          yaml(
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: actions/checkout@v4
+                      name: Checkout
+                    - uses: actions/setup-java@v4
+                      name: Not on allow list
+              """,
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+                      name: Checkout
+                    - uses: actions/setup-java@v4
+                      name: Not on allow list
+              """,
+            sourceSpecs -> sourceSpecs.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void emptyAllowListBehavesAsDefault() {
+        rewriteRun(
+          spec -> spec.recipe(new PinGitHubActionsToSha(false, null, Collections.emptyList())),
+          yaml(
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: codecov/codecov-action@v4
+                      name: Coverage
+              """,
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+                      name: Coverage
+              """,
+            sourceSpecs -> sourceSpecs.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
     void shouldMixPinnedAndUnpinnedActions() {
         rewriteRun(
-          spec -> spec.recipe(new PinGitHubActionsToSha(true, null)),
+          spec -> spec.recipe(new PinGitHubActionsToSha(true, null, null)),
           yaml(
             """
               name: Full Pipeline


### PR DESCRIPTION
## Summary

Adds an `includedActions` option to `PinGitHubActionsToSha` that, when supplied, restricts pinning to only the actions matching one of the patterns in the list. Pattern forms supported:

| Pattern | Matches |
|---|---|
| `owner/repo` | Exact `owner/repo`, with or without a subpath in the `uses:` |
| `owner/*` | Any repo in an org |
| `owner/repo/subpath` | Exact match including subpath |

When the allow list is non-empty, an explicit allow always wins — `pinOfficialActions` is bypassed for matched entries — so e.g. `actions/checkout` can be pinned via the allow list without globally flipping the official-actions flag. An omitted or empty list preserves today's default behavior.

- The base of this PR is the [pin-actions-to-sha](https://github.com/openrewrite/rewrite-github-actions/tree/pin-actions-to-sha) branch — intended to be folded into #169 before merging to `main`.

## Test plan

- [x] `shouldOnlyPinAllowListedActions` — only listed actions are rewritten; off-list third-party actions stay untouched
- [x] `shouldSupportOrgWildcardInAllowList` — `docker/*` pins every action in the `docker` org; other orgs untouched
- [x] `allowListMatchesActionWithSubpathByOwnerRepo` — `gradle/actions` matches `gradle/actions/setup-gradle@…`
- [x] `allowListWithSubpathPatternIsExact` — `gradle/actions/setup-gradle` does **not** match `gradle/actions/wrapper-validation`
- [x] `allowListPinsOfficialActionWithoutPinOfficialFlag` — explicit allow overrides the official-org skip
- [x] `emptyAllowListBehavesAsDefault` — `Collections.emptyList()` is treated identically to `null`
- [x] All 13 pre-existing tests in `PinGitHubActionsToShaTest` still pass