### PR TITLE
Fix tag comment placement when pinned `uses:` is followed by a sequence boundary

### DIFF
--- a/src/main/java/org/openrewrite/github/security/PinGitHubActionsToSha.java
+++ b/src/main/java/org/openrewrite/github/security/PinGitHubActionsToSha.java
@@ -129,90 +129,52 @@ public class PinGitHubActionsToSha extends ScanningRecipe<Map<String, String>> {
                 new IsGitHubActionsWorkflow(),
                 new YamlIsoVisitor<ExecutionContext>() {
 
+                    /**
+                     * When a {@code uses:} entry is pinned, the formatted ref comment is stashed
+                     * here so the very next syntactic node visited (in document order) can have it
+                     * merged into its prefix as a {@code # vX} marker on the same line as the
+                     * pinned value. Consumed and cleared by whichever of {@link #visitMappingEntry},
+                     * {@link #visitSequenceEntry}, or {@link #visitDocumentEnd} fires next.
+                     */
+                    @Nullable
+                    String pendingComment;
+
                     @Override
-                    public Yaml.Mapping visitMapping(Yaml.Mapping mapping, ExecutionContext ctx) {
-                        Yaml.Mapping m = super.visitMapping(mapping, ctx);
-                        List<Yaml.Mapping.Entry> entries = m.getEntries();
-                        List<Yaml.Mapping.Entry> newEntries = new ArrayList<>(entries);
-                        boolean changed = false;
-
-                        for (int i = 0; i < newEntries.size(); i++) {
-                            Yaml.Mapping.Entry e = newEntries.get(i);
-                            PinResult result = pinEntry(e, ctx);
-                            if (result != null) {
-                                newEntries.set(i, result.entry);
-                                if (i + 1 < newEntries.size()) {
-                                    // Append tag comment to the prefix of the next sibling
-                                    Yaml.Mapping.Entry next = newEntries.get(i + 1);
-                                    newEntries.set(i + 1, next.withPrefix(mergeTagCommentIntoPrefix(next.getPrefix(), result.commentText)));
-                                } else {
-                                    // Last entry — use doAfterVisit to place comment on the next printed node
-                                    scheduleCommentAfterEntry(result.entry.getId(), result.commentText);
-                                }
-                                changed = true;
-                            }
-                        }
-
-                        return changed ? m.withEntries(newEntries) : m;
+                    public Yaml.Documents visitDocuments(Yaml.Documents documents, ExecutionContext ctx) {
+                        pendingComment = null;
+                        return super.visitDocuments(documents, ctx);
                     }
 
-                    private void scheduleCommentAfterEntry(UUID pinnedEntryId, String commentText) {
-                        doAfterVisit(new YamlIsoVisitor<ExecutionContext>() {
-                            private boolean found;
+                    @Override
+                    public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                        if (pendingComment != null) {
+                            entry = entry.withPrefix(mergeTagCommentIntoPrefix(entry.getPrefix(), pendingComment));
+                            pendingComment = null;
+                        }
+                        PinResult result = pinEntry(entry, ctx);
+                        if (result != null) {
+                            entry = result.entry;
+                            pendingComment = result.commentText;
+                        }
+                        return super.visitMappingEntry(entry, ctx);
+                    }
 
-                            @Override
-                            public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
-                                Yaml.Mapping.Entry e = super.visitMappingEntry(entry, ctx);
-                                if (e.getId().equals(pinnedEntryId)) {
-                                    found = true;
-                                }
-                                return e;
-                            }
+                    @Override
+                    public Yaml.Sequence.Entry visitSequenceEntry(Yaml.Sequence.Entry entry, ExecutionContext ctx) {
+                        if (pendingComment != null) {
+                            entry = entry.withPrefix(mergeTagCommentIntoPrefix(entry.getPrefix(), pendingComment));
+                            pendingComment = null;
+                        }
+                        return super.visitSequenceEntry(entry, ctx);
+                    }
 
-                            @Override
-                            public Yaml.Mapping visitMapping(Yaml.Mapping mapping, ExecutionContext ctx) {
-                                Yaml.Mapping m = super.visitMapping(mapping, ctx);
-                                if (!found) {
-                                    return m;
-                                }
-                                // Check if the pinned entry is in this mapping and find its successor
-                                List<Yaml.Mapping.Entry> entries = m.getEntries();
-                                for (int i = 0; i < entries.size() - 1; i++) {
-                                    if (containsEntry(entries.get(i), pinnedEntryId)) {
-                                        Yaml.Mapping.Entry next = entries.get(i + 1);
-                                        List<Yaml.Mapping.Entry> updated = new ArrayList<>(entries);
-                                        updated.set(i + 1, next.withPrefix(mergeTagCommentIntoPrefix(next.getPrefix(), commentText)));
-                                        found = false; // consumed
-                                        return m.withEntries(updated);
-                                    }
-                                }
-                                return m;
-                            }
-
-                            @Override
-                            public Yaml.Document.End visitDocumentEnd(Yaml.Document.End end, ExecutionContext ctx) {
-                                Yaml.Document.End e = super.visitDocumentEnd(end, ctx);
-                                if (found) {
-                                    e = e.withPrefix(mergeTagCommentIntoPrefix(e.getPrefix(), commentText));
-                                    found = false;
-                                }
-                                return e;
-                            }
-
-                            private boolean containsEntry(Yaml.Mapping.Entry entry, UUID targetId) {
-                                if (entry.getId().equals(targetId)) {
-                                    return true;
-                                }
-                                if (entry.getValue() instanceof Yaml.Mapping) {
-                                    for (Yaml.Mapping.Entry child : ((Yaml.Mapping) entry.getValue()).getEntries()) {
-                                        if (containsEntry(child, targetId)) {
-                                            return true;
-                                        }
-                                    }
-                                }
-                                return false;
-                            }
-                        });
+                    @Override
+                    public Yaml.Document.End visitDocumentEnd(Yaml.Document.End end, ExecutionContext ctx) {
+                        if (pendingComment != null) {
+                            end = end.withPrefix(mergeTagCommentIntoPrefix(end.getPrefix(), pendingComment));
+                            pendingComment = null;
+                        }
+                        return super.visitDocumentEnd(end, ctx);
                     }
 
                     private @Nullable PinResult pinEntry(Yaml.Mapping.Entry e, ExecutionContext ctx) {

--- a/src/test/java/org/openrewrite/github/security/PinGitHubActionsToShaTest.java
+++ b/src/test/java/org/openrewrite/github/security/PinGitHubActionsToShaTest.java
@@ -330,6 +330,72 @@ class PinGitHubActionsToShaTest implements RewriteTest {
     }
 
     @Test
+    void shouldPlaceCommentOnSameLineWhenUsesIsLastEntryAndAnotherStepFollows() {
+        rewriteRun(
+          yaml(
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - name: Coverage
+                      uses: codecov/codecov-action@v4
+                    - uses: docker/setup-buildx-action@v3
+                      name: Buildx
+              """,
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - name: Coverage
+                      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+                    - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+                      name: Buildx
+              """,
+            sourceSpecs -> sourceSpecs.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
+    void shouldPlaceCommentOnSameLineWhenTopLevelEntryFollowsJobs() {
+        rewriteRun(
+          yaml(
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - name: Coverage
+                      uses: codecov/codecov-action@v4
+              env:
+                FOO: bar
+              """,
+            """
+              name: CI
+              on: push
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - name: Coverage
+                      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+              env:
+                FOO: bar
+              """,
+            sourceSpecs -> sourceSpecs.path(".github/workflows/ci.yml")
+          )
+        );
+    }
+
+    @Test
     void shouldReplaceExistingInlineCommentWithVersionTag() {
         rewriteRun(
           yaml(


### PR DESCRIPTION
## Summary

When `PinGitHubActionsToSha` pinned a `uses:` declaration that was the **last entry** of its containing mapping, the `# vX` marker ended up on the wrong line. Three reported variants share the same root cause:

- the pinned `uses:` had a trailing user comment, and `# vX` then escaped all the way to `Document.End`;
- the pinned `uses:` was the only entry in a step, with another step following — `# vX` either disappeared or landed on a deeply unrelated entry many lines below;
- the pinned `uses:` was the final entry of a step whose other entry was a sub-mapping (e.g. `with:`), and `# vX` ended up inline with some leaf inside that sub-mapping or a later one.

Cause: the placement logic walked entries within a single mapping and, when the pinned entry was the last one, scheduled a `doAfterVisit` that recursively scanned through `Yaml.Mapping` containers only. That can't cross a `Yaml.Sequence` boundary, so the comment either attached to an unrelated entry in an outer mapping or fell through to the document end.

Fix: replace the post-order iteration + `scheduleCommentAfterEntry` walker with a `pendingComment` field on the visitor that is set the moment a `uses:` is pinned and consumed by whichever of `visitMappingEntry`, `visitSequenceEntry`, or `visitDocumentEnd` fires next in document order. That places the marker on the same line as the pinned value in every case, including across sequence boundaries and at the seam between sibling top-level mapping entries. When the pinned `uses:` line already has a trailing user comment (variant 1), the existing `mergeTagCommentIntoPrefix` helper replaces it with `# vX` per the Dependabot/Renovate convention encoded there — so the marker lands inline with the SHA rather than escaping to `Document.End`, at the cost of overwriting the original comment.

Existing tests for the recipe (including the trailing-comment-replacement and document-end cases) continue to pass — the fix covers a strictly broader set of inputs.

## Test plan

- [x] `./gradlew test --tests 'org.openrewrite.github.security.PinGitHubActionsToShaTest'` — 27 / 27 pass on the new code; the two new tests fail on `main` (verified by stashing the fix and re-running).
- [x] `./gradlew test` — full module suite, 323 / 323 pass.

## New regression tests

- `shouldPlaceCommentOnSameLineWhenUsesIsLastEntryAndAnotherStepFollows` — pinned `uses:` is the last entry of step 1, and another step follows. Without the fix, the comment lands on `name: Buildx` two steps below.
- `shouldPlaceCommentOnSameLineWhenTopLevelEntryFollowsJobs` — pinned `uses:` is buried in `jobs.build.steps` and a top-level `env:` block follows. Without the fix, the comment lands on `FOO: bar` inside `env:`.
