### PR TITLE
Tolerate actions with no matching version tags in update-known-shas

### DIFF
--- a/.github/scripts/update-known-shas.sh
+++ b/.github/scripts/update-known-shas.sh
@@ -241,8 +241,10 @@ while IFS= read -r action_path; do
   owner_repo=$(owner_repo_of "$action_path")
 
   # Fetch all version tags: v1, v1.2, v1.2.3 (not pre-release or non-numeric suffixes)
+  # `|| true` keeps the script alive when the action has no matching tags
+  # (grep exits 1 on no matches, which would otherwise trip `pipefail`).
   TAGS=$(gh api "repos/${owner_repo}/tags" --paginate --jq '.[].name' 2>/dev/null \
-    | grep -E '^v[0-9]+(\.[0-9]+){0,2}$' | sort -V)
+    | grep -E '^v[0-9]+(\.[0-9]+){0,2}$' | sort -V) || true
 
   while IFS= read -r tag; do
     [[ -z "$tag" ]] && continue


### PR DESCRIPTION
## Summary

The scheduled `update-known-shas` job was failing because `grep` exits 1 when an action's tags don't match the `v<N>[.<N>[.<N>]]` pattern (e.g. `bazel-contrib/setup-bazel`, which uses `release-X.Y.Z`). Combined with `set -euo pipefail`, that aborted the whole script mid-loop.

Appending `|| true` to the `TAGS=...` command substitution lets the loop skip those actions cleanly — the existing `[[ -z "$tag" ]] && continue` guard already handles an empty result.

## Test plan

- [ ] Next scheduled `update-known-shas.yml` run completes without exit code 1