### PR TITLE
Forward CGP artifact repository credentials for dependency resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@tim/cgp-artifacts-maven-credentials
+    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       sonatype_username: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
+    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@tim/cgp-artifacts-maven-credentials
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
@@ -30,3 +30,5 @@ jobs:
       OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
       cgp_aws_access_key_id: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
       cgp_aws_secret_access_key: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}
+      cgp_artifacts_maven_username: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+      cgp_artifacts_maven_token: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,5 +20,7 @@ jobs:
       sonatype_token: ${{ secrets.SONATYPE_TOKEN}}
       ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
       ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+      cgp_aws_access_key_id: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
+      cgp_aws_secret_access_key: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}
       cgp_artifacts_maven_username: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
       cgp_artifacts_maven_token: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,3 +20,5 @@ jobs:
       sonatype_token: ${{ secrets.SONATYPE_TOKEN}}
       ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
       ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+      cgp_artifacts_maven_username: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+      cgp_artifacts_maven_token: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}


### PR DESCRIPTION
Follow-up to openrewrite/gh-automation#102, which is now merged.

Forwards the org-level `CGP_ARTIFACTS_MAVEN_USERNAME` / `CGP_ARTIFACTS_MAVEN_TOKEN` secrets to the shared `ci-gradle.yml` and `publish-gradle.yml` workflows, which export them as `ORG_GRADLE_PROJECT_codegenomeUsername` / `ORG_GRADLE_PROJECT_codegenomePassword`. `org.openrewrite.build.recipe-repositories` reads those to add https://artifacts.codegenomeproject.org/maven as a group-scoped repository for `org.openrewrite` and `io.moderne`, as of rewrite-build-gradle-plugin v2.21.0 — which this repo already picks up via `latest.release`.

Verified against the gh-automation PR branch before it merged, in [run 30554003195](https://github.com/openrewrite/rewrite-github-actions/actions/runs/30554003195): the build resolved `rewrite-yaml` and `rewrite-test` `8.89.0-SNAPSHOT` through `artifacts.codegenomeproject.org` with no auth errors, while still querying Maven Central and Central snapshots alongside. A control run on `main` showed no CGP resolution at all, so the credentials are demonstrably taking effect.